### PR TITLE
Updating Dockerfile to run health adapter directly

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -20,4 +20,4 @@ ENV NODE_ID=""
 ENV BIND_ADDRESS=""
 ENV UNHEALTHY_LAG=""
 
-ENTRYPOINT /usr/local/bin/dshackle_health_adapter --bind-address $BIND_ADDRESS --health-url $HEALTH_URL --node-id $NODE_ID --unhealthy-lag UNHEALTHY_LAG
+ENTRYPOINT /usr/local/bin/dshackle_health_adapter --bind-address $BIND_ADDRESS --health-url $HEALTH_URL --node-id $NODE_ID --unhealthy-lag $UNHEALTHY_LAG

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -15,4 +15,8 @@ FROM docker.io/debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates tini && apt-get clean
 COPY --from=cargo-build /src/target/release/dshackle_health_adapter /usr/local/bin/dshackle_health_adapter
 
-ENTRYPOINT ["/usr/bin/tini"]
+ENV HEALTH_URL=""
+ENV NODE_ID=""
+ENV BIND_ADDRESS=""
+
+ENTRYPOINT /usr/local/bin/dshackle_health_adapter --bind-address $BIND_ADDRESS --health-url $HEALTH_URL --node-id $NODE_ID

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -18,5 +18,6 @@ COPY --from=cargo-build /src/target/release/dshackle_health_adapter /usr/local/b
 ENV HEALTH_URL=""
 ENV NODE_ID=""
 ENV BIND_ADDRESS=""
+ENV UNHEALTHY_LAG=""
 
-ENTRYPOINT /usr/local/bin/dshackle_health_adapter --bind-address $BIND_ADDRESS --health-url $HEALTH_URL --node-id $NODE_ID
+ENTRYPOINT /usr/local/bin/dshackle_health_adapter --bind-address $BIND_ADDRESS --health-url $HEALTH_URL --node-id $NODE_ID --unhealthy-lag UNHEALTHY_LAG


### PR DESCRIPTION
This PR updates the Dockerfile to allow the users to run the docker container directly and pass environment variables for configurations.

### Manual testing
* Build the docker image, `docker build --tag dshackle_health_adapter -f ./docker/Dockerfile.binary .`
* Run the image using, `docker run -e HEALTH_URL='http://DSHACKLE_URL:8082/health?detailed' -e BINDING_ADDRESS='0.0.0.0:8080' -e NODE_ID='cow-nethermind' -d -p 8080:8080 dshackle_health_adapter`